### PR TITLE
Test prometheus rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,27 @@ jobs:
           command: |
             /scripts/publish-chart.sh
 
+  testPrometheusRules:
+    docker:
+      - image: web3f/ci-commons:v1.6.0
+    steps:
+      - checkout
+      - run:
+          name: Install missing dependencies
+          command: |
+            YQ_VER=3.3.0
+            wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VER}/yq_linux_amd64
+            chmod +x /usr/local/bin/yq
+
+            PROM_VER=2.18.1
+            wget -O /tmp/prometheus.tgz https://github.com/prometheus/prometheus/releases/download/v${PROM_VER}/prometheus-${PROM_VER}.linux-amd64.tar.gz
+            tar -xvf /tmp/prometheus.tgz prometheus-${PROM_VER}.linux-amd64/promtool -C /tmp
+            mv /tmp/prometheus-$PROM_VER.linux-amd64/promtool /usr/local/bin/
+      - run:
+          command: |
+            scripts/test_prometheus_rules.sh
+
+
 workflows:
   version: 2
   test-deploy:
@@ -28,7 +49,10 @@ workflows:
           filters:
             branches:
               only: /master/
+      - testPrometheusRules
       - publishChart:
+          requires:
+            - testPrometheusRules
           filters:
             branches:
               ignore: /.*/

--- a/charts/polkadot/templates/alertrules.yaml
+++ b/charts/polkadot/templates/alertrules.yaml
@@ -1,0 +1,82 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-alertrules
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  groups:
+  - name: polkadot.rules
+    rules:
+    - alert: LowNumberOfPeersShort
+      annotations:
+        message: 'The node has less than 3 peers for 3 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: polkadot_sub_libp2p_peers_count < 3
+      for: 3m
+      labels:
+        severity: warning
+    - alert: LowNumberOfPeersLong
+      annotations:
+        message: 'The node has less than 3 peers for 15 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: polkadot_sub_libp2p_peers_count < 3
+      for: 15m
+      labels:
+        severity: critical
+    - alert: TransactionQueueSizeShort
+      annotations:
+        message: 'The node has more than 10 transactions in the queue for more than 10 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: polkadot_sub_txpool_validations_scheduled > 10
+      for: 10m
+      labels:
+        severity: warning
+    - alert: TransactionQueueSizeLong
+      annotations:
+        message: 'The node has more than 10 transactions in the queue for more than 30 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: polkadot_sub_txpool_validations_scheduled > 10
+      for: 30m
+      labels:
+        severity: critical
+    - alert: LowNumberOfNewBlocksShort
+      annotations:
+        message: 'The number of new blocks has not increased for the last 3 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: increase(polkadot_block_height{status="best"}[1m]) == 0
+      for: 3m
+      labels:
+        severity: warning
+    - alert: LowNumberOfNewBlocksLong
+      annotations:
+        message: 'The number of new blocks has not increased for the last 10 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: increase(polkadot_block_height{status="best"}[1m]) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: LowNumberOfFinalizedBlocksShort
+      annotations:
+        message: 'The number of finalized blocks has not increased for the last 3 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: increase(polkadot_block_height{status="finalized"}[1m]) == 0
+      for: 3m
+      labels:
+        severity: warning
+    - alert: LowNumberOfFinalizedBlocksLong
+      annotations:
+        message: 'The number of finalized blocks has not increased for the last 10 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: increase(polkadot_block_height{status="finalized"}[1m]) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: HighCPUUsage
+      annotations:
+        message: 'The node has a CPU usage higher than 100% for 5 minutes'
+        # runbook_url: "https://github.com/w3f/infrastructure/wiki/<LINK>"
+      expr: polkadot_cpu_usage_percentage >= 100
+      for: 5m
+      labels:
+        severity: warning

--- a/scripts/test_prometheus_rules.sh
+++ b/scripts/test_prometheus_rules.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+TEST_FOLDER="tests/prometheus"
+for file in $(find "${TEST_FOLDER}" -name *yaml | sed 's|^'"${TEST_FOLDER}"/'||'); do
+    chart_name=${file%%/*}
+    template_name=${file##*/}
+
+    helm template -x "templates/${template_name}" "charts/${chart_name}" | yq r - spec | promtool check rules /dev/stdin
+    helm template -x "templates/${template_name}" "charts/${chart_name}" | yq r - spec | promtool test rules "${TEST_FOLDER}/${chart_name}/${template_name}"
+done

--- a/tests/prometheus/polkadot/alertrules.yaml
+++ b/tests/prometheus/polkadot/alertrules.yaml
@@ -1,0 +1,149 @@
+rule_files:
+    - /dev/stdin
+
+evaluation_interval: 1m
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'polkadot_sub_libp2p_peers_count{job="polkadot", pod="polkadot-abcdef01234-abcdef"}'
+            values: '3 2+0x4 1+0x9' # 3 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1
+          - series: 'polkadot_sub_txpool_validations_scheduled{job="polkadot", pod="polkadot-abcdef01234-abcdef"}'
+            values: '10+1x30' # 10 11 12 13 .. 40
+          - series: 'polkadot_block_height{status="best", job="polkadot", pod="polkadot-abcdef01234-abcdef"}'
+            values: '1+1x3 4+0x13' # 1 2 3 4 4 4 4 4 4 4 4 4 ...
+          - series: 'polkadot_block_height{status="finalized", job="polkadot", pod="polkadot-abcdef01234-abcdef"}'
+            values: '1+1x3 4+0x13' # 1 2 3 4 4 4 4 4 4 4 4 4 ...
+          - series: 'polkadot_cpu_usage_percentage{job="polkadot", pod="polkadot-abcdef01234-abcdef"}'
+            values: '0+20x5 100+0x5' # 0 20 40 60 80 100 100 100 100 100 100
+
+      alert_rule_test:
+          # Test LowNumberOfPeersShort alert
+          - eval_time: 3m # Values: 3 2 2
+            alertname: LowNumberOfPeersShort
+            exp_alerts:
+          - eval_time: 4m # Values: 2 2 2
+            alertname: LowNumberOfPeersShort
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                  exp_annotations:
+                      message: "The node has less than 3 peers for 3 minutes"
+
+          # Test LowNumberOfPeersLong alert
+          - eval_time: 15m # Values: 3 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1
+            alertname: LowNumberOfPeersLong
+            exp_alerts:
+          - eval_time: 16m # Values: 3 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1
+            alertname: LowNumberOfPeersLong
+            exp_alerts:
+                - exp_labels:
+                      severity: critical
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                  exp_annotations:
+                      message: "The node has less than 3 peers for 15 minutes"
+
+          # Test TransactionQueueSizeShort alert
+          - eval_time: 10m
+            alertname: TransactionQueueSizeShort
+            exp_alerts:
+          - eval_time: 11m
+            alertname: TransactionQueueSizeShort
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                  exp_annotations:
+                      message: "The node has more than 10 transactions in the queue for more than 10 minutes"
+
+          # Test TransactionQueueSizeLong alert
+          - eval_time: 30m
+            alertname: TransactionQueueSizeLong
+            exp_alerts:
+          - eval_time: 31m
+            alertname: TransactionQueueSizeLong
+            exp_alerts:
+                - exp_labels:
+                      severity: critical
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                  exp_annotations:
+                      message: "The node has more than 10 transactions in the queue for more than 30 minutes"
+
+          # Test LowNumberOfNewBlocksShort alert
+          - eval_time: 6m
+            alertname: LowNumberOfNewBlocksShort
+            exp_alerts:
+          - eval_time: 7m
+            alertname: LowNumberOfNewBlocksShort
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                      status: best
+                  exp_annotations:
+                      message: "The number of new blocks has not increased for the last 3 minutes"
+
+          # Test LowNumberOfNewBlocksLong alert
+          - eval_time: 13m
+            alertname: LowNumberOfNewBlocksLong
+            exp_alerts:
+          - eval_time: 14m
+            alertname: LowNumberOfNewBlocksLong
+            exp_alerts:
+                - exp_labels:
+                      severity: critical
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                      status: best
+                  exp_annotations:
+                      message: "The number of new blocks has not increased for the last 10 minutes"
+
+          # Test LowNumberOfFinalizedBlocksShort alert
+          - eval_time: 6m
+            alertname: LowNumberOfFinalizedBlocksShort
+            exp_alerts:
+          - eval_time: 7m
+            alertname: LowNumberOfFinalizedBlocksShort
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                      status: finalized
+                  exp_annotations:
+                      message: "The number of finalized blocks has not increased for the last 3 minutes"
+
+          # Test LowNumberOfFinalizedBlocksLong alert
+          - eval_time: 13m
+            alertname: LowNumberOfFinalizedBlocksLong
+            exp_alerts:
+          - eval_time: 14m
+            alertname: LowNumberOfFinalizedBlocksLong
+            exp_alerts:
+                - exp_labels:
+                      severity: critical
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                      status: finalized
+                  exp_annotations:
+                      message: "The number of finalized blocks has not increased for the last 10 minutes"
+
+          # Test HighCPUUsage alert
+          - eval_time: 9m
+            alertname: HighCPUUsage
+            exp_alerts:
+          - eval_time: 10m
+            alertname: HighCPUUsage
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                      pod: polkadot-abcdef01234-abcdef
+                      job: polkadot
+                  exp_annotations:
+                      message: "The node has a CPU usage higher than 100% for 5 minutes"


### PR DESCRIPTION
This PR extends PR #5 and adds [unit tests for created prometheus alert rules](https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/).

Things to consider:
- Add following dependencies into `web3f/ci-commons` docker image
  - [yq](https://github.com/mikefarah/yq) 
  - [promtool](https://github.com/prometheus/prometheus/tree/master/cmd/promtool)
